### PR TITLE
CI: Update AppVeyor to Visual Studio 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ In order to run the highest resolution supported by the SVT-VP9 Encoder, at leas
 
 ## Windows* Operating Systems (64-bit):
 
-* __Build Requirements__
-    -    Visual Studio* 2017 (can be downloaded [here](https://www.visualstudio.com/vs/older-downloads/))
-    -    CMake 3.5 or later (can be downloaded [here](https://github.com/Kitware/CMake/releases/download/v3.13.0/cmake-3.13.0-win64-x64.msi))
-    -   YASM Assembler version 1.2.0 or later
-    -    Download the yasm exe from the following [link](http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe)
-    -    Rename yasm-1.3.0-win64.exe to yasm.exe
-    -   Copy yasm.exe into a location that is in the PATH environment variable
+- __Build Requirements__
+  - Visual Studio* 2017 (download [here](https://www.visualstudio.com/vs/older-downloads/)) or 2019 (download [here](https://visualstudio.microsoft.com/downloads/))
+  - CMake 3.14 or later (download [here](https://github.com/Kitware/CMake/releases/download/v3.14.4/cmake-3.14.4-win64-x64.msi))
+  - YASM Assembler version 1.2.0 or later
+    - Download the yasm exe from the following [link](http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe)
+    - Rename yasm-1.3.0-win64.exe to yasm.exe
+    - Copy yasm.exe into a location that is in the PATH environment variable
 
 * __Build Instructions__
     -    Generate the Visual Studio* 2017 project files by following the steps below cd Build\windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 
 install:
     - git submodule update --init
     - appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -FileName yasm.exe
     - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
-    - cmake . -G "Visual Studio 15 2017 Win64" -DCMAKE_ASM_NASM_COMPILER="yasm.exe"
+    - cmake . -G "Visual Studio 16 2019" -A x64 -DCMAKE_ASM_NASM_COMPILER="yasm.exe"
 
 build:
   project: svt-vp9.sln


### PR DESCRIPTION
Updates AppVeyor to Visual Studio 2019 (version 16.1).