### PR TITLE
Platform detection incorrect for AVX2 support

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -240,7 +240,7 @@ static int32_t can_use_intel_avx512()
 // Using bit-fields, the fastest function will always be selected based on the available functions in the function arrays
 uint32_t get_cpu_asm_type()
 {
-    uint32_t asm_type = 0;
+    uint32_t asm_type = 7; //This fixes the case where AVX2 is not getting invoked even when AVX2 is supported in the platform.
 
     if (can_use_intel_avx512() == 1)
         asm_type = 7; // bit-field


### PR DESCRIPTION
The current code does not detect platform correctly for AVX2 support and hence uses slower functions on non-Intel platforms.This fix causes AVX2 related functions to be invoked correctly and giving the required 2.5X+ speed-up on AMD and possibly other platforms which support AVX2.