### PR TITLE
Don't set affinity if didn't specify -ss

### DIFF
--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -642,8 +642,10 @@ void eb_set_thread_management_parameters( EbSvtVp9EncConfiguration *config_ptr){
     if (num_groups == 1) {
         uint32_t lps = config_ptr->logical_processors == 0 ? num_logical_processors :
             config_ptr->logical_processors < num_logical_processors ? config_ptr->logical_processors : num_logical_processors;
-        for (uint32_t i = 0; i < lps; i++)
-            CPU_SET(lp_group[0].group[i], &group_affinity);
+            if (config_ptr->target_socket != -1) {
+                for (uint32_t i = 0; i < lps; i++)
+                    CPU_SET(lp_group[0].group[i], &group_affinity);
+            }
     }
     else if (num_groups > 1) {
         uint32_t num_lp_per_group = num_logical_processors / num_groups;


### PR DESCRIPTION
User can still use taskset to specify the cores, this works for non-numa
CPU cases

Signed-off-by: Jing Li <jing.b.li@intel.com>