### PR TITLE
AppVeyor: Only deploy Release build to GitHub releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,3 +22,4 @@ deploy:
     prerelease: true
     on:
       appveyor_repo_tag: true
+      configuration: Release


### PR DESCRIPTION
To prevent OpenVisualCloud/SVT-HEVC#361