### PR TITLE
Appveyor: Add debug and release msvc and mingw builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,25 +1,108 @@
 image: Visual Studio 2019
-configuration: Release
+configuration:
+  - Release
+  - Debug
+
+environment:
+  MSYSTEM: MINGW64
+  MSYS2_PATH_TYPE: inherit
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+  matrix:
+    - generator: Visual Studio 2019
+    - generator: Unix Makefiles
+      CC: ccache gcc
+      CXX: ccache g++
+      CFLAGS: -mtune=generic -mthreads -pipe
+
+matrix:
+  fast_finish: true
 
 install:
-    - git submodule update --init
-    - appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -FileName yasm.exe
-    - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
-    - cmake . -G "Visual Studio 16 2019" -A x64 -DCMAKE_ASM_NASM_COMPILER="yasm.exe"
+  - set "PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%"
+  - pacman -Sy --ask=20 --noconfirm --noprogressbar --needed mingw-w64-x86_64-yasm mingw-w64-x86_64-ccache mingw-w64-x86_64-cmake mingw-w64-x86_64-gcc pkg-config make
+  - pacman -Sc --noconfirm
+  - cd Build
 
-build:
-  project: svt-vp9.sln
+for:
+  - matrix:
+      only:
+        - generator: Unix Makefiles
+    before_build:
+      - cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=C:/msys64/mingw64 -DBUILD_SHARED_LIBS=OFF
+    build_script:
+      - make -j install
+    after_build:
+      - cd %APPVEYOR_BUILD_FOLDER% &&
+        set "ARTIFACT_FILES=%APPVEYOR_BUILD_FOLDER%\Bin\%configuration%\libSvtVp9Enc.a %APPVEYOR_BUILD_FOLDER%\Bin\%configuration%\SvtVp9EncApp.exe"
+      - if "%configuration%"=="Release" (
+        set "CFLAGS=%CFLAGS% -O2" &&
+        set "PKG_CONFIG_PATH=C:/msys64/mingw64/lib/pkgconfig" &&
+        wget -q https://github.com/FFmpeg/FFmpeg/archive/master.zip &&
+        7z x -aoa master.zip &&
+        cd FFmpeg-master &&
+        patch -p1 -tsNli %APPVEYOR_BUILD_FOLDER%/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch &&
+        bash ./configure --prefix=/mingw64 --arch=x86_64 --cc="ccache gcc" --cxx="ccache g++" --disable-{ffplay,ffprobe,doc,debug} --enable-{libsvtvp9,encoder=libsvt_vp9} &&
+        make -sj install
+        )
+
+  - matrix:
+      only:
+        - generator: Visual Studio 2019
+    before_build:
+      - cmake .. -G"Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=%SYSTEMDRIVE%\svt-encoders
+    build:
+      parallel: true
+      project: Build\svt-vp9.sln
+    after_build:
+      - cmake --build . --config %configuration% --target install
+      - cd %APPVEYOR_BUILD_FOLDER% &&
+        set "ARTIFACT_FILES=%APPVEYOR_BUILD_FOLDER%\Bin\%configuration%\SvtVp9Enc.dll %APPVEYOR_BUILD_FOLDER%\Bin\%configuration%\SvtVp9Enc.exp %APPVEYOR_BUILD_FOLDER%\Bin\%configuration%\SvtVp9Enc.lib %APPVEYOR_BUILD_FOLDER%\Bin\%configuration%\SvtVp9EncApp.exe" &&
+        set "CFLAGS=%CFLAGS% -O2" && set "PATH=%SYSTEMDRIVE%\svt-encoders\bin;%PATH%" &&
+        set CC=ccache gcc &&
+        set CXX=ccache g++
+      - if "%configuration%"=="Debug" ( exit 0 ) else (
+        set "PKG_CONFIG_PATH=%SYSTEMDRIVE%/svt-encoders/lib/pkgconfig" &
+        wget -q https://github.com/FFmpeg/FFmpeg/archive/master.zip &
+        7z x -aoa master.zip &
+        cd FFmpeg-master &
+        patch -p1 -tsNli %APPVEYOR_BUILD_FOLDER%/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch &
+        bash ./configure --prefix=/mingw64 --arch=x86_64 --cc="ccache gcc" --cxx="ccache g++" --disable-{ffplay,ffprobe,doc,debug} --enable-{libsvtvp9,encoder=libsvt_vp9} &
+        make -sj install
+        )
+
+before_test:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - 7z a -aoa -mx9 SVT-VP9.tar %ARTIFACT_FILES%
+  - if "%configuration%"=="Release" 7z a -aoa -mx9 SVT-VP9.tar %APPVEYOR_BUILD_FOLDER%\FFmpeg-master\ffmpeg.exe
+  - 7z a -aoa -mx9 SVT-VP9.tar.xz SVT-VP9.tar
+  - dash -c 'ccache -s'
+  - ps: if ($env:configuration -eq "Release") {
+      foreach ($file in "Bin\Release\SvtVp9Enc.dll Bin\Release\SvtVp9Enc.exp Bin\Release\SvtVp9Enc.lib Bin\Release\SvtVp9EncApp.exe".Split()) {
+      Push-AppveyorArtifact $file -DeploymentName $env:APPVEYOR_PROJECT_NAME
+      }
+      }
+
+test_script:
+  - curl --connect-timeout 15 --retry 3 --retry-delay 5 -sLkf https://raw.githubusercontent.com/OpenVisualCloud/SVT-AV1-Resources/master/video.tar.gz | tar xz
+  - SvtVp9EncApp -n 50 -enc-mode 9 -i akiyo_cif.y4m -w 352 -h 288 -fps-num 30000 -fps-denom 1001 -b test1.ivf
+  - if "%configuration%"=="Release" ffmpeg -i akiyo_cif.y4m -c:v libsvt_vp9 test.ivf
+  - cd %APPVEYOR_BUILD_FOLDER%
 
 artifacts:
-    - path: bin\Release\*.*
-      name: $(APPVEYOR_PROJECT_NAME)
+  - path: SVT-VP9.tar.xz
+    name: $(APPVEYOR_PROJECT_NAME)-$(configuration)-$(generator)
 
 deploy:
   - provider: GitHub
     artifact: $(APPVEYOR_PROJECT_NAME)
     auth_token:
-      secure: 'sf0pQXlPI+X6LoAR8QUJB74jjzNxcLGOXI3H0nbxJq8llvGPG/TAUd87hq5iHZXo'
+      secure: "sf0pQXlPI+X6LoAR8QUJB74jjzNxcLGOXI3H0nbxJq8llvGPG/TAUd87hq5iHZXo"
     prerelease: true
     on:
       appveyor_repo_tag: true
+      generator: Visual Studio 2019
       configuration: Release
+
+cache:
+  - 'C:\msys64\home\appveyor\.ccache'
+  - 'C:\msys64\var\cache\pacman\pkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,8 @@ before_test:
   - if "%configuration%"=="Release" 7z a -aoa -mx9 SVT-VP9.tar %APPVEYOR_BUILD_FOLDER%\FFmpeg-master\ffmpeg.exe
   - 7z a -aoa -mx9 SVT-VP9.tar.xz SVT-VP9.tar
   - dash -c 'ccache -s'
-  - ps: if ($env:configuration -eq "Release") {
+  - ps:
+      if ($env:configuration -eq "Release" -and $env:APPVEYOR_REPO_TAG -eq "true") {
       foreach ($file in "Bin\Release\SvtVp9Enc.dll Bin\Release\SvtVp9Enc.exp Bin\Release\SvtVp9Enc.lib Bin\Release\SvtVp9EncApp.exe".Split()) {
       Push-AppveyorArtifact $file -DeploymentName $env:APPVEYOR_PROJECT_NAME
       }


### PR DESCRIPTION
Add ffmpeg compiling for release builds

Compress the archives before adding them to artifacts

First builds will be around 30+ minutes for release builds since the ccache cache won't be populated,
Takes around 10 minutes afterwards

The SVT-VP9.tar.xz in the artifacts tab will include the dlls, exe, and a copy of ffmpeg.exe with libsvt_vp9 for release builds, I think this should be fine since we aren't compiling non-free and afaik none of the license is being violated.

The github releases should still be fine


@EwoutH, please check to see if there is anything that needs to be improved or is wrong, I am planning to submit similar changes for SVT-{HEVC,AV1} soon

This should help with the artifact sizes a little bit