### PR TITLE
Removing -irefresh-type option from VP9 encoder

### DIFF
--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -44,7 +44,6 @@ BaseLayerSwitchMode             : 0             # 0 : Use B-frames in the base l
 PredStructure                   : 2             # 2: Random Access
 
 IntraPeriod                     : 47            # Period of I-Frame (-1 = only first, -2 = auto) [-2 - 255]
-IntraRefreshType                : 2             # Random Access 1:CRA, 2:IDR (when intra_period > 0) - [1-2]
 
 #====================== Quantization ===============================
 QP                              : 56            # Quantization parameter - [0-63]

--- a/Docs/svt-vp9_encoder_user_guide.md
+++ b/Docs/svt-vp9_encoder_user_guide.md
@@ -117,6 +117,7 @@ The encoder parameters present in the Sample.cfg file are listed in this table b
 | **AsmType** | -asm | [0 - 1] | 1 | Assembly instruction set (0 = C Only, 1 = Automatically select highest assembly instruction set supported) |
 | **LogicalProcessorNumber** | -lp | [0, total number of logical processor] | 0 | The number of logical processor which encoder threads run on.Refer to Appendix A.1 |
 | **TargetSocket** | -ss | [-1,1] | -1 | For dual socket systems, this can specify which socket the encoder runs on.Refer to Appendix A.1 |
+| **SwitchThreadsToRtPriority** | -rt | [0 - 1] | 1 | Enables or disables threads to real time priority, 0 = OFF, 1 = ON (only works on Linux) |
 | **Profile** | -profile | [0] | 0 | 0 = 8-bit 4:2:0 |
 | **Level** | -level | [1, 2, 2.1,3, 3.1, 4, 4.1, 5, 5.1, 5.2, 6, 6.1, 6.2] | 0 | 0 to 6.2 [0 for auto determine Level] |
 
@@ -145,8 +146,7 @@ Visual Studio* 2017 offers Profile Guided Optimization (PGO) to improve compiler
 
 Some Linux\* Operating systems and kernels assign CPU utilization limits to applications running on servers. Therefore, to allow the application to utilize up to ~100% of the CPUs assigned to it, it is best to run the following commands before and when running the encoder:
   > sudo  sysctl  -w  kernel.sched\_rt\_runtime\_us=1000000
-  >
-  >   - this command should be executed every time the server is rebooted
+    - this command should be executed every time the server is rebooted
 
 The above section is not needed for Windows\* as it does not perform the CPU utilization limitation on the application.
 

--- a/Docs/svt-vp9_encoder_user_guide.md
+++ b/Docs/svt-vp9_encoder_user_guide.md
@@ -145,8 +145,7 @@ Visual Studio* 2017 offers Profile Guided Optimization (PGO) to improve compiler
 #### Linux* OS (Tested on Ubuntu* Server 18.04 and 16.04)
 
 Some Linux\* Operating systems and kernels assign CPU utilization limits to applications running on servers. Therefore, to allow the application to utilize up to ~100% of the CPUs assigned to it, it is best to run the following commands before and when running the encoder:
-  > sudo  sysctl  -w  kernel.sched\_rt\_runtime\_us=1000000
-    - this command should be executed every time the server is rebooted
+  > sudo  sysctl  -w  kernel.sched\_rt\_runtime\_us=1000000 - this command should be executed every time the server is rebooted
 
 The above section is not needed for Windows\* as it does not perform the CPU utilization limitation on the application.
 

--- a/Docs/svt-vp9_encoder_user_guide.md
+++ b/Docs/svt-vp9_encoder_user_guide.md
@@ -145,7 +145,8 @@ Visual Studio* 2017 offers Profile Guided Optimization (PGO) to improve compiler
 #### Linux* OS (Tested on Ubuntu* Server 18.04 and 16.04)
 
 Some Linux\* Operating systems and kernels assign CPU utilization limits to applications running on servers. Therefore, to allow the application to utilize up to ~100% of the CPUs assigned to it, it is best to run the following commands before and when running the encoder:
-  > sudo  sysctl  -w  kernel.sched\_rt\_runtime\_us=1000000 - this command should be executed every time the server is rebooted
+  > sudo  sysctl  -w  kernel.sched\_rt\_runtime\_us=1000000
+  - this command should be executed every time the server is rebooted
 
 The above section is not needed for Windows\* as it does not perform the CPU utilization limitation on the application.
 

--- a/Docs/svt-vp9_encoder_user_guide.md
+++ b/Docs/svt-vp9_encoder_user_guide.md
@@ -60,7 +60,7 @@ The number of frames of the sequence to encode.  e.g. 100. If the input frame co
 
 >-intra-period integer **[Optional]**
 
-The intra period defines the interval of frames after which you insert an Intra refresh. It is strongly recommended to use (multiple of 8) -1 the closest to 1 second (e.g. 55, 47, 31, 23 should be used for 60, 50, 30, (24 or 25) respectively). When using closed gop (-irefresh-type 2) add 1 to the value above (e.g. 56 instead of 55).
+The intra period defines the interval of frames after which you insert an Intra refresh. It is strongly recommended to use (multiple of 8) -1 the closest to 1 second (e.g. 55, 47, 31, 23 should be used for 60, 50, 30, (24 or 25) respectively). Because all intra refreshes are closed gop add 1 to the value above (e.g. 56 instead of 55).
 
 >-rc integer **[Optional]**
 
@@ -102,7 +102,6 @@ The encoder parameters present in the Sample.cfg file are listed in this table b
 | **BaseLayerSwitchMode** | -base-layer-switch-mode | [0 - 1] | 0 | 0 = Use B-frames in the base layer pointing to the same past picture. <br>1 = Use P-frames in the base layer|
 | **PredStructure** | -pred-struct | [2] | 2 | 2 = Random Access.|
 | **IntraPeriod** | -intra-period | [-2 - 255] | -2 | Distance Between Intra Frame inserted. -1 denotes no intra update. -2 denotes auto. |
-| **IntraRefreshType** | -irefresh-type | [1 - 2] | 2 | 1 = CRA (Open GOP) <br>2 = IDR (Closed GOP) |
 | **QP** | -q | [0 - 63] | 50 | Initial quantization parameter for the Intra pictures used when RateControlMode 0 (CQP) |
 | **LoopFilter** | -loop-filter | [0 - 1] | 1 | Enables or disables the loop filter, <br>0 = OFF, 1 = ON |
 | **UseDefaultMeHme** | -use-default-me-hme | [0 - 1] | 1 | 0 = Overwrite Default ME HME parameters. <br>1 = Use default ME HME parameters, dependent on width and height |
@@ -117,7 +116,7 @@ The encoder parameters present in the Sample.cfg file are listed in this table b
 | **MinQpAllowed** | -min-qp | [0 - 63] | 10 | Minimum QP value allowed for rate control use. Only used when RateControlMode is set to 1. Has to be < MaxQpAllowed |
 | **AsmType** | -asm | [0 - 1] | 1 | Assembly instruction set (0 = C Only, 1 = Automatically select highest assembly instruction set supported) |
 | **LogicalProcessorNumber** | -lp | [0, total number of logical processor] | 0 | The number of logical processor which encoder threads run on.Refer to Appendix A.1 |
-| **TargetSocket** | -ss | [-1,1] | -1 | For dual socket systems, this can specify which socket the encoder runs on.Refer to Appendix A.1 || **SwitchThreadsToRtPriority** | -rt | [0 - 1] | 1 | Enables or disables threads to real time priority, 0 = OFF, 1 = ON (only works on Linux) |
+| **TargetSocket** | -ss | [-1,1] | -1 | For dual socket systems, this can specify which socket the encoder runs on.Refer to Appendix A.1 |
 | **Profile** | -profile | [0] | 0 | 0 = 8-bit 4:2:0 |
 | **Level** | -level | [1, 2, 2.1,3, 3.1, 4, 4.1, 5, 5.1, 5.2, 6, 6.1, 6.2] | 0 | 0 to 6.2 [0 for auto determine Level] |
 
@@ -146,7 +145,8 @@ Visual Studio* 2017 offers Profile Guided Optimization (PGO) to improve compiler
 
 Some Linux\* Operating systems and kernels assign CPU utilization limits to applications running on servers. Therefore, to allow the application to utilize up to ~100% of the CPUs assigned to it, it is best to run the following commands before and when running the encoder:
   > sudo  sysctl  -w  kernel.sched\_rt\_runtime\_us=1000000
-  - this command should be executed every time the server is rebooted
+  >
+  >   - this command should be executed every time the server is rebooted
 
 The above section is not needed for Windows\* as it does not perform the CPU utilization limitation on the application.
 

--- a/Source/API/EbSvtVp9Enc.h
+++ b/Source/API/EbSvtVp9Enc.h
@@ -153,12 +153,6 @@ typedef struct EbSvtVp9EncConfiguration
     * Deault is -2. */
     int32_t                  intra_period;
 
-    /* Random access.
-    * 1 = CRA, open GOP.
-    * 2 = IDR, closed GOP.
-    * Default is 1. */
-    uint32_t                 intra_refresh_type;
-
     /* Prediction structure used to construct GOP. There are two main structures
     * supported, which are: Low Delay (P or B) and Random Access.
     *

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -47,7 +47,6 @@
 #define LEVEL_TOKEN                     "-level"
 #define INTERLACED_VIDEO_TOKEN          "-interlaced-video"
 #define SEPERATE_FILDS_TOKEN            "-separate-fields"
-#define INTRA_REFRESH_TYPE_TOKEN        "-irefresh-type" // no Eval
 #define LOOP_FILTER_TOKEN               "-loop-filter"
 #define USE_DEFAULT_ME_HME_TOKEN        "-use-default-me-hme"
 #define HME_ENABLE_TOKEN                "-hme"      // no Eval
@@ -145,7 +144,6 @@ static void set_encoder_bit_depth                      (const char *value, EbCon
 static void set_base_layer_switch_mode                 (const char *value, EbConfig *cfg) {cfg->base_layer_switch_mode              = (uint8_t) strtoul(value, NULL, 0);};
 static void set_enc_mode                               (const char *value, EbConfig *cfg) {cfg->enc_mode                            = (uint8_t)strtoul(value, NULL, 0);};
 static void set_cfg_intra_period                       (const char *value, EbConfig *cfg) {cfg->intra_period                        = strtol(value,  NULL, 0);};
-static void set_cfg_intra_refresh_type                 (const char *value, EbConfig *cfg) {cfg->intra_refresh_type                  = strtol(value,  NULL, 0);};
 static void set_cfg_pred_structure                     (const char *value, EbConfig *cfg) { cfg->pred_structure                     = strtol(value, NULL, 0); };
 static void set_cfg_qp                                 (const char *value, EbConfig *cfg) {cfg->qp                                  = strtoul(value, NULL, 0);};
 static void set_cfg_use_qp_file                        (const char *value, EbConfig *cfg) {cfg->use_qp_file                         = (uint8_t)strtol(value, NULL, 0); };
@@ -222,7 +220,6 @@ ConfigEntry config_entry[] = {
     { SINGLE_INPUT, BASE_LAYER_SWITCH_MODE_TOKEN, "BaseLayerSwitchMode", set_base_layer_switch_mode },
     { SINGLE_INPUT, ENCMODE_TOKEN, "EncoderMode", set_enc_mode},
     { SINGLE_INPUT, INTRA_PERIOD_TOKEN, "IntraPeriod", set_cfg_intra_period },
-    { SINGLE_INPUT, INTRA_REFRESH_TYPE_TOKEN, "IntraRefreshType", set_cfg_intra_refresh_type },
     { SINGLE_INPUT, FRAME_RATE_TOKEN, "FrameRate", set_frame_rate },
     { SINGLE_INPUT, FRAME_RATE_NUMERATOR_TOKEN, "FrameRateNumerator", set_frame_rate_numerator },
     { SINGLE_INPUT, FRAME_RATE_DENOMINATOR_TOKEN, "FrameRateDenominator", set_frame_rate_denominator },
@@ -311,7 +308,6 @@ void eb_config_ctor(EbConfig *config_ptr)
 
     config_ptr->enc_mode                                         = 9;
     config_ptr->intra_period                                     = -2;
-    config_ptr->intra_refresh_type                               = 2;
 
     config_ptr->pred_structure                                   = 2;
 

--- a/Source/App/EbAppConfig.h
+++ b/Source/App/EbAppConfig.h
@@ -220,7 +220,6 @@ typedef struct EbConfig
     uint32_t        base_layer_switch_mode;
     uint8_t         enc_mode;
     int32_t         intra_period;
-    uint32_t        intra_refresh_type;
     uint32_t        pred_structure;
 
     /****************************************

--- a/Source/App/EbAppContext.c
+++ b/Source/App/EbAppContext.c
@@ -158,7 +158,6 @@ EbErrorType  copy_configuration_parameters(
     callback_data->eb_enc_parameters.source_width = config->source_width;
     callback_data->eb_enc_parameters.source_height = config->source_height;
     callback_data->eb_enc_parameters.intra_period = config->intra_period;
-    callback_data->eb_enc_parameters.intra_refresh_type = config->intra_refresh_type;
     callback_data->eb_enc_parameters.base_layer_switch_mode = config->base_layer_switch_mode;
     callback_data->eb_enc_parameters.enc_mode = (uint8_t)config->enc_mode;
     callback_data->eb_enc_parameters.frame_rate = config->frame_rate;

--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -320,15 +320,6 @@ typedef struct EbH265DynEncConfiguration {
     uint32_t available_target_bitrate;
 } EbH265DynEncConfiguration;
 
-/** The EbIntraRefreshType is used to describe the intra refresh type.
-*/
-typedef enum EbIntraRefreshType
-{
-    NO_REFRESH = 0,
-    CRA_REFRESH = 1,
-    IDR_REFRESH = 2
-} EbIntraRefreshType;
-
 #ifdef __GNUC__
 #define EB_ALIGN(n) __attribute__((__aligned__(n)))
 #elif defined(_MSC_VER)

--- a/Source/Lib/Codec/EbEncodeContext.c
+++ b/Source/Lib/Codec/EbEncodeContext.c
@@ -168,7 +168,6 @@ EbErrorType eb_vp9_encode_context_ctor(
     encode_context_ptr->pred_struct_position                                = 0;
     encode_context_ptr->current_input_poc                                   = -1;
     encode_context_ptr->elapsed_non_idr_count                                = 0;
-    encode_context_ptr->elapsed_non_cra_count                                = 0;
     encode_context_ptr->initial_picture                                    = EB_TRUE;
 
     encode_context_ptr->last_idr_picture                                    = 0;

--- a/Source/Lib/Codec/EbEncodeContext.h
+++ b/Source/Lib/Codec/EbEncodeContext.h
@@ -110,7 +110,6 @@ typedef struct EncodeContext
     uint32_t                            pred_struct_position;         // Current position within a prediction structure
 
     uint32_t                            elapsed_non_idr_count;
-    uint32_t                            elapsed_non_cra_count;
     int64_t                             current_input_poc;
     EB_BOOL                             initial_picture;
 

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -239,8 +239,6 @@ typedef struct PictureParentControlSet
     EbObjectWrapper                                   *pareference_picture_wrapper_ptr;
 
     EB_BOOL                                            idr_flag;
-    EB_BOOL                                            cra_flag; // Hsan - to remove
-    EB_BOOL                                            open_gop_cra_flag;
     EB_BOOL                                            scene_change_flag;
     EB_BOOL                                            end_of_sequence_flag;
 

--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -1644,10 +1644,7 @@ void* eb_vp9_picture_decision_kernel(void *input_ptr)
 
            // If the Intra period length is 0, then introduce an intra for every picture
            if (sequence_control_set_ptr->intra_period == 0 || picture_control_set_ptr->picture_number == 0 ) {
-               if (sequence_control_set_ptr->intra_refresh_type == CRA_REFRESH)
-                   picture_control_set_ptr->cra_flag = EB_TRUE;
-               else
-                   picture_control_set_ptr->idr_flag = EB_TRUE;
+               picture_control_set_ptr->idr_flag = EB_TRUE;
            }
            // If an #IntraPeriodLength has passed since the last Intra, then introduce a CRA or IDR based on Intra Refresh type
            else if (sequence_control_set_ptr->intra_period != -1) {

--- a/Source/Lib/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Codec/EbPictureDecisionProcess.c
@@ -1653,17 +1653,7 @@ void* eb_vp9_picture_decision_kernel(void *input_ptr)
            else if (sequence_control_set_ptr->intra_period != -1) {
                if ((encode_context_ptr->intra_period_position == (uint32_t)sequence_control_set_ptr->intra_period) ||
                    (picture_control_set_ptr->scene_change_flag == EB_TRUE)) {
-                   if (sequence_control_set_ptr->intra_refresh_type == CRA_REFRESH)
-                       picture_control_set_ptr->cra_flag = EB_TRUE;
-                   else
-                       picture_control_set_ptr->idr_flag = EB_TRUE;
-               }
-               if ((encode_context_ptr->intra_period_position == (uint32_t)sequence_control_set_ptr->intra_period) ||
-                   (picture_control_set_ptr->scene_change_flag == EB_TRUE)) {
-                   if (sequence_control_set_ptr->intra_refresh_type == CRA_REFRESH)
-                       picture_control_set_ptr->cra_flag = EB_TRUE;
-                   else
-                       picture_control_set_ptr->idr_flag = EB_TRUE;
+                   picture_control_set_ptr->idr_flag = EB_TRUE;
                }
            }
 

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -686,7 +686,6 @@ void* eb_vp9_resource_coordination_kernel(void *input_ptr)
 
         // Set Picture Control Flags
         picture_control_set_ptr->idr_flag = sequence_control_set_ptr->encode_context_ptr->initial_picture || (picture_control_set_ptr->eb_input_ptr->pic_type == EB_IDR_PICTURE);
-        picture_control_set_ptr->cra_flag = (picture_control_set_ptr->eb_input_ptr->pic_type == EB_I_PICTURE) ? EB_TRUE : EB_FALSE;
         picture_control_set_ptr->scene_change_flag                 = EB_FALSE;
 
         picture_control_set_ptr->qp_on_the_fly                      = EB_FALSE;

--- a/Source/Lib/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Codec/EbSequenceControlSet.c
@@ -82,7 +82,6 @@ EbErrorType eb_vp9_sequence_control_set_ctor(
     // GOP Structure
     sequence_control_set_ptr->max_ref_count                                      = 1;
     sequence_control_set_ptr->intra_period                                       = 0;
-    sequence_control_set_ptr->intra_refresh_type                                 = 0;
 
     // Rate Control
     sequence_control_set_ptr->rate_control_mode                                  = 0;
@@ -175,7 +174,6 @@ EbErrorType eb_vp9_copy_sequence_control_set(
     dst->output_bitdepth             = src->output_bitdepth;                          write_count += sizeof(EbBitDepth);
     dst->pred_struct_ptr             = src->pred_struct_ptr;                          write_count += sizeof(PredictionStructure*);
     dst->intra_period                = src->intra_period;                             write_count += sizeof(int32_t);
-    dst->intra_refresh_type          = src->intra_refresh_type;                       write_count += sizeof(uint32_t);
     dst->max_ref_count               = src->max_ref_count;                            write_count += sizeof(uint32_t);
     dst->target_bit_rate             = src->target_bit_rate;                          write_count += sizeof(uint32_t);
     dst->available_bandwidth         = src->available_bandwidth;                      write_count += sizeof(uint32_t);

--- a/Source/Lib/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Codec/EbSequenceControlSet.h
@@ -61,7 +61,6 @@ typedef struct SequenceControlSet
                                                        //   entry can be less.
     PredictionStructure       *pred_struct_ptr;
     int32_t                    intra_period;      // The frequency of intra pictures
-    uint32_t                   intra_refresh_type;       // 1: CRA, 2: IDR
     uint32_t                   look_ahead_distance;
 
     // Rate Control

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-hevc-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-hevc-av1.patch
@@ -12,12 +12,12 @@ Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
  libavcodec/Makefile       |   1 +
  libavcodec/allcodecs.c    |   1 +
  libavcodec/avcodec.h      |   2 +
- libavcodec/libsvt_vp9.c   | 485 ++++++++++++++++++++++++++++++++++++++
+ libavcodec/libsvt_vp9.c   | 482 ++++++++++++++++++++++++++++++++++++++
  libavformat/dashenc.c     |  49 +++-
  libavformat/ivfenc.c      |  34 ++-
  libavformat/matroskaenc.c | 108 ++++++++-
  libavformat/movenc.c      |  42 +++-
- 9 files changed, 716 insertions(+), 10 deletions(-)
+ 9 files changed, 713 insertions(+), 10 deletions(-)
  create mode 100644 libavcodec/libsvt_vp9.c
 
 diff --git a/configure b/configure
@@ -95,10 +95,10 @@ index d234271c5b..0d903571b3 100644
      AV_SIDE_DATA_PARAM_CHANGE_CHANNEL_COUNT  = 0x0001,
 diff --git a/libavcodec/libsvt_vp9.c b/libavcodec/libsvt_vp9.c
 new file mode 100644
-index 0000000000..d51e2985c8
+index 0000000000..d2c4740e5c
 --- /dev/null
 +++ b/libavcodec/libsvt_vp9.c
-@@ -0,0 +1,485 @@
+@@ -0,0 +1,482 @@
 +/*
 +* Scalable Video Technology for VP9 encoder library plugin
 +*
@@ -288,9 +288,6 @@ index 0000000000..d51e2985c8
 +        param->max_qp_allowed       = avctx->qmax;
 +        param->min_qp_allowed       = avctx->qmin;
 +    }
-+
-+    param->intra_refresh_type       =
-+        !!(avctx->flags & AV_CODEC_FLAG_CLOSED_GOP) + 1;
 +
 +    if (ten_bits) {
 +        param->encoder_bit_depth        = 10;
@@ -884,10 +881,10 @@ index cef504fa05..de8e3872c1 100644
          if (pkt->size > 2 && (AV_RB16(pkt->data) & 0xfff0) == 0xfff0)
              ret = ff_stream_add_bitstream_filter(st, "aac_adtstoasc", NULL);
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index a96139077b..e73cbb24c4 100644
+index 4d4d0cd024..eeebf10147 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
-@@ -5622,7 +5622,43 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
+@@ -5624,7 +5624,43 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
              }
          }
  
@@ -932,7 +929,7 @@ index a96139077b..e73cbb24c4 100644
  }
  
  static int mov_write_subtitle_end_packet(AVFormatContext *s,
-@@ -6758,6 +6794,10 @@ static int mov_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
+@@ -6763,6 +6799,10 @@ static int mov_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
      int ret = 1;
      AVStream *st = s->streams[pkt->stream_index];
  
@@ -945,4 +942,3 @@ index a96139077b..e73cbb24c4 100644
              ret = ff_stream_add_bitstream_filter(st, "aac_adtstoasc", NULL);
 -- 
 2.20.1
-

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch
@@ -1,4 +1,4 @@
-From 8690dd16b653a54b797dc0dafea751ccec45ce3b Mon Sep 17 00:00:00 2001
+From 3eb3aa5e26fb0f0f2724ce8ec50b8a54d206cb25 Mon Sep 17 00:00:00 2001
 From: hassene <hassene.tmar@intel.com>
 Date: Fri, 15 Feb 2019 17:43:54 -0800
 Subject: [PATCH] Add ability for ffmpeg to run svt vp9
@@ -12,12 +12,12 @@ Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
  libavcodec/Makefile       |   1 +
  libavcodec/allcodecs.c    |   1 +
  libavcodec/avcodec.h      |   2 +
- libavcodec/libsvt_vp9.c   | 485 ++++++++++++++++++++++++++++++++++++++
+ libavcodec/libsvt_vp9.c   | 482 ++++++++++++++++++++++++++++++++++++++
  libavformat/dashenc.c     |  49 +++-
  libavformat/ivfenc.c      |  34 ++-
  libavformat/matroskaenc.c | 108 ++++++++-
  libavformat/movenc.c      |  42 +++-
- 9 files changed, 716 insertions(+), 10 deletions(-)
+ 9 files changed, 713 insertions(+), 10 deletions(-)
  create mode 100644 libavcodec/libsvt_vp9.c
 
 diff --git a/configure b/configure
@@ -95,10 +95,10 @@ index d234271c5b..0d903571b3 100644
      AV_SIDE_DATA_PARAM_CHANGE_CHANNEL_COUNT  = 0x0001,
 diff --git a/libavcodec/libsvt_vp9.c b/libavcodec/libsvt_vp9.c
 new file mode 100644
-index 0000000000..d51e2985c8
+index 0000000000..d2c4740e5c
 --- /dev/null
 +++ b/libavcodec/libsvt_vp9.c
-@@ -0,0 +1,485 @@
+@@ -0,0 +1,482 @@
 +/*
 +* Scalable Video Technology for VP9 encoder library plugin
 +*
@@ -288,9 +288,6 @@ index 0000000000..d51e2985c8
 +        param->max_qp_allowed       = avctx->qmax;
 +        param->min_qp_allowed       = avctx->qmin;
 +    }
-+
-+    param->intra_refresh_type       =
-+        !!(avctx->flags & AV_CODEC_FLAG_CLOSED_GOP) + 1;
 +
 +    if (ten_bits) {
 +        param->encoder_bit_depth        = 10;
@@ -585,7 +582,7 @@ index 0000000000..d51e2985c8
 +    .wrapper_name   = "libsvt_vp9",
 +};
 diff --git a/libavformat/dashenc.c b/libavformat/dashenc.c
-index 24d43c34ea..f5f578c72b 100644
+index 24d43c34ea..ba47bd6413 100644
 --- a/libavformat/dashenc.c
 +++ b/libavformat/dashenc.c
 @@ -1823,6 +1823,48 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
@@ -884,10 +881,10 @@ index cef504fa05..de8e3872c1 100644
          if (pkt->size > 2 && (AV_RB16(pkt->data) & 0xfff0) == 0xfff0)
              ret = ff_stream_add_bitstream_filter(st, "aac_adtstoasc", NULL);
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index a96139077b..e73cbb24c4 100644
+index 4d4d0cd024..eeebf10147 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
-@@ -5622,7 +5622,43 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
+@@ -5624,7 +5624,43 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
              }
          }
  
@@ -932,7 +929,7 @@ index a96139077b..e73cbb24c4 100644
  }
  
  static int mov_write_subtitle_end_packet(AVFormatContext *s,
-@@ -6758,6 +6794,10 @@ static int mov_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
+@@ -6763,6 +6799,10 @@ static int mov_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
      int ret = 1;
      AVStream *st = s->streams[pkt->stream_index];
  
@@ -944,5 +941,5 @@ index a96139077b..e73cbb24c4 100644
          if (pkt->size > 2 && (AV_RB16(pkt->data) & 0xfff0) == 0xfff0)
              ret = ff_stream_add_bitstream_filter(st, "aac_adtstoasc", NULL);
 -- 
-2.17.1
+2.23.0.windows.1
 

--- a/gstreamer-plugin/gstsvtvp9enc.c
+++ b/gstreamer-plugin/gstsvtvp9enc.c
@@ -83,7 +83,6 @@ enum
   PROP_P_FRAMES,
   PROP_PRED_STRUCTURE,
   PROP_GOP_SIZE,
-  PROP_INTRA_REFRESH,
   PROP_QP,
   PROP_DEBLOCKING,
   PROP_CONSTRAINED_INTRA,
@@ -107,7 +106,6 @@ enum
 #define PROP_P_FRAMES_DEFAULT               FALSE
 #define PROP_PRED_STRUCTURE_DEFAULT         2
 #define PROP_GOP_SIZE_DEFAULT               -1
-#define PROP_INTRA_REFRESH_DEFAULT          1
 #define PROP_QP_DEFAULT                     45
 #define PROP_DEBLOCKING_DEFAULT             TRUE
 #define PROP_CONSTRAINED_INTRA_DEFAULT      FALSE
@@ -238,13 +236,6 @@ gst_svtvp9enc_class_init (GstSvtVp9EncClass * klass)
           -1, 251, PROP_GOP_SIZE_DEFAULT,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
-  g_object_class_install_property (gobject_class, PROP_INTRA_REFRESH,
-      g_param_spec_int ("intra-refresh", "Intra refresh type",
-          "CRA (open GOP)"
-          "or IDR (closed GOP)",
-          1, 2, PROP_INTRA_REFRESH_DEFAULT,
-          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
-
   g_object_class_install_property (gobject_class, PROP_QP,
       g_param_spec_uint ("qp", "Quantization parameter",
           "Quantization parameter used in CQP mode",
@@ -364,9 +355,6 @@ gst_svtvp9enc_set_property (GObject * object, guint property_id,
     case PROP_GOP_SIZE:
         svtvp9enc->svt_config->intra_period = g_value_get_int(value) - 1;
         break;
-    case PROP_INTRA_REFRESH:
-        svtvp9enc->svt_config->intra_refresh_type = g_value_get_int(value);
-        break;
     case PROP_SPEEDCONTROL:
       if (g_value_get_uint (value) > 0) {
         svtvp9enc->svt_config->injector_frame_rate = g_value_get_uint (value);
@@ -460,9 +448,6 @@ gst_svtvp9enc_get_property (GObject * object, guint property_id,
       break;
     case PROP_GOP_SIZE:
       g_value_set_int (value, svtvp9enc->svt_config->intra_period + 1);
-      break;
-    case PROP_INTRA_REFRESH:
-        g_value_set_int(value, svtvp9enc->svt_config->intra_refresh_type);
       break;
     case PROP_QP:
       g_value_set_uint (value, svtvp9enc->svt_config->qp);
@@ -639,7 +624,6 @@ set_default_svt_configuration (EbSvtVp9EncConfiguration * svt_config)
   svt_config->source_width = 0;
   svt_config->source_height = 0;
   svt_config->intra_period = PROP_GOP_SIZE_DEFAULT - 1;
-  svt_config->intra_refresh_type = PROP_INTRA_REFRESH_DEFAULT;
   svt_config->enc_mode = PROP_ENCMODE_DEFAULT;
   svt_config->tune = PROP_TUNE_DEFAULT;
   svt_config->frame_rate = 25;


### PR DESCRIPTION
Removed duplicated check for scene change or intra_period start

Force idr_flag on (VP9 does not appear to support cra in bitstreams)

Signed-off-by: Mark Feldman <mark.feldman@intel.com>