### PR TITLE
App/EbAppContext.c: Remove unused stream_buffer_pool and allocate_output_buffers

### DIFF
--- a/Source/App/EbAppContext.c
+++ b/Source/App/EbAppContext.c
@@ -323,28 +323,6 @@ EbErrorType allocate_output_recon_buffers(
     return return_error;
 }
 
-EbErrorType allocate_output_buffers(
-    EbConfig     *config,
-    EbAppContext *callback_data)
-{
-
-    EbErrorType   return_error = EB_ErrorNone;
-    uint32_t           output_stream_buffer_size = (uint32_t)(EB_OUTPUTSTREAMBUFFERSIZE_MACRO(config->source_height * config->source_width));;
-    {
-        EB_APP_MALLOC(EbBufferHeaderType*, callback_data->stream_buffer_pool, sizeof(EbBufferHeaderType), EB_N_PTR, EB_ErrorInsufficientResources);
-
-        // Initialize Header
-        callback_data->stream_buffer_pool->size = sizeof(EbBufferHeaderType);
-
-        EB_APP_MALLOC(uint8_t*, callback_data->stream_buffer_pool->p_buffer, output_stream_buffer_size, EB_N_PTR, EB_ErrorInsufficientResources);
-
-        callback_data->stream_buffer_pool->n_alloc_len = output_stream_buffer_size;
-        callback_data->stream_buffer_pool->p_app_private = NULL;
-        callback_data->stream_buffer_pool->pic_type = EB_INVALID_PICTURE;
-    }
-    return return_error;
-}
-
 EbErrorType  preload_frames_into_ram(
     EbConfig *config)
 {
@@ -446,16 +424,7 @@ EbErrorType init_encoder(
         return return_error;
     }
 
-    // STEP 7: Allocate output buffers carrying the bitstream out
-    return_error = allocate_output_buffers(
-        config,
-        callback_data);
-
-    if (return_error != EB_ErrorNone) {
-        return return_error;
-    }
-
-    // STEP 8: Allocate output Recon Buffer
+    // STEP 7: Allocate output Recon Buffer
     return_error = allocate_output_recon_buffers(
         config,
         callback_data);

--- a/Source/App/EbAppContext.h
+++ b/Source/App/EbAppContext.h
@@ -25,7 +25,6 @@ typedef struct EbAppContext_s
 
     // Buffer Pools
     EbBufferHeaderType          *input_buffer_pool;
-    EbBufferHeaderType          *stream_buffer_pool;
     EbBufferHeaderType          *recon_buffer;
 
     // Instance Index


### PR DESCRIPTION
Since nothing is currently using the buffer pool

Matching SVT-HEVC PR: https://github.com/OpenVisualCloud/SVT-HEVC/pull/527
Matching SVT-AV1 PR: OpenVisualCloud/SVT-AV1#1209