### PR TITLE
EbThreads: use lowercase windows.h for case sensitive systems

### DIFF
--- a/Source/Lib/Codec/EbThreads.h
+++ b/Source/Lib/Codec/EbThreads.h
@@ -10,7 +10,7 @@
 #include "EbDefinitions.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
On nix systems with mingw-w64, gcc will error out on `Windows.h` since they do not do case insensitive include search