### PR TITLE
ffmpeg: Adapt with new libavcodec internal encode api changes

### DIFF
--- a/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-hevc-av1.patch
+++ b/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-hevc-av1.patch
@@ -1,4 +1,4 @@
-From cbc80321d678f779bba9a23b89d421c3619ac8e4 Mon Sep 17 00:00:00 2001
+From 1b3939631a36826439a5ae759107ef40716473c0 Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Mon, 1 Apr 2019 17:17:00 +0800
 Subject: [PATCH] Add ability for ffmpeg to run svt vp9 with hevc & av1
@@ -12,12 +12,12 @@ Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
  libavcodec/Makefile       |   1 +
  libavcodec/allcodecs.c    |   1 +
  libavcodec/avcodec.h      |   3 +
- libavcodec/libsvt_vp9.c   | 511 ++++++++++++++++++++++++++++++++++++++
+ libavcodec/libsvt_vp9.c   | 504 ++++++++++++++++++++++++++++++++++++++
  libavformat/dashenc.c     |  49 +++-
  libavformat/ivfenc.c      |  30 ++-
  libavformat/matroskaenc.c | 112 ++++++++-
- libavformat/movenc.c      |  41 ++-
- 9 files changed, 739 insertions(+), 13 deletions(-)
+ libavformat/movenc.c      |  41 +++-
+ 9 files changed, 732 insertions(+), 13 deletions(-)
  create mode 100644 libavcodec/libsvt_vp9.c
 
 diff --git a/configure b/configure
@@ -96,10 +96,10 @@ index c91b2fd169..ae4a8de889 100644
   * Export the AVVideoEncParams structure through frame side data.
 diff --git a/libavcodec/libsvt_vp9.c b/libavcodec/libsvt_vp9.c
 new file mode 100644
-index 0000000000..35498f3a77
+index 0000000000..6bd6243de0
 --- /dev/null
 +++ b/libavcodec/libsvt_vp9.c
-@@ -0,0 +1,511 @@
+@@ -0,0 +1,504 @@
 +/*
 +* Scalable Video Technology for VP9 encoder library plugin
 +*
@@ -132,9 +132,7 @@ index 0000000000..35498f3a77
 +#include "libavutil/opt.h"
 +
 +#include "internal.h"
-+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
 +#include "encode.h"
-+#endif
 +#include "avcodec.h"
 +
 +typedef enum eos_status {
@@ -467,7 +465,6 @@ index 0000000000..35498f3a77
 +        return AVERROR_EOF;
 +    }
 +
-+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
 +    ret = ff_encode_get_frame(avctx, frame);
 +    if (ret < 0 && ret != AVERROR_EOF)
 +        return ret;
@@ -476,7 +473,6 @@ index 0000000000..35498f3a77
 +
 +    eb_send_frame(avctx, frame);
 +    av_frame_unref(svt_enc->frame);
-+#endif
 +
 +    svt_ret = eb_vp9_svt_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
 +    if (svt_ret == EB_NoErrorEmptyQueue)
@@ -598,9 +594,6 @@ index 0000000000..35498f3a77
 +    .type           = AVMEDIA_TYPE_VIDEO,
 +    .id             = AV_CODEC_ID_VP9,
 +    .init           = eb_enc_init,
-+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 93, 100)
-+    .send_frame     = eb_send_frame,
-+#endif
 +    .receive_packet = eb_receive_packet,
 +    .close          = eb_enc_close,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,

--- a/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-hevc-av1.patch
+++ b/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9-with-hevc-av1.patch
@@ -1,4 +1,4 @@
-From fa7ad43e47b3daaf08a0f2e3fd5d52bdc28076d0 Mon Sep 17 00:00:00 2001
+From cbc80321d678f779bba9a23b89d421c3619ac8e4 Mon Sep 17 00:00:00 2001
 From: Jing Sun <jing.a.sun@intel.com>
 Date: Mon, 1 Apr 2019 17:17:00 +0800
 Subject: [PATCH] Add ability for ffmpeg to run svt vp9 with hevc & av1
@@ -12,12 +12,12 @@ Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
  libavcodec/Makefile       |   1 +
  libavcodec/allcodecs.c    |   1 +
  libavcodec/avcodec.h      |   3 +
- libavcodec/libsvt_vp9.c   | 482 ++++++++++++++++++++++++++++++++++++++
+ libavcodec/libsvt_vp9.c   | 511 ++++++++++++++++++++++++++++++++++++++
  libavformat/dashenc.c     |  49 +++-
  libavformat/ivfenc.c      |  30 ++-
  libavformat/matroskaenc.c | 112 ++++++++-
- libavformat/movenc.c      |  41 +++-
- 9 files changed, 710 insertions(+), 13 deletions(-)
+ libavformat/movenc.c      |  41 ++-
+ 9 files changed, 739 insertions(+), 13 deletions(-)
  create mode 100644 libavcodec/libsvt_vp9.c
 
 diff --git a/configure b/configure
@@ -96,10 +96,10 @@ index c91b2fd169..ae4a8de889 100644
   * Export the AVVideoEncParams structure through frame side data.
 diff --git a/libavcodec/libsvt_vp9.c b/libavcodec/libsvt_vp9.c
 new file mode 100644
-index 0000000000..edddc01b8d
+index 0000000000..35498f3a77
 --- /dev/null
 +++ b/libavcodec/libsvt_vp9.c
-@@ -0,0 +1,482 @@
+@@ -0,0 +1,511 @@
 +/*
 +* Scalable Video Technology for VP9 encoder library plugin
 +*
@@ -132,6 +132,9 @@ index 0000000000..edddc01b8d
 +#include "libavutil/opt.h"
 +
 +#include "internal.h"
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
++#include "encode.h"
++#endif
 +#include "avcodec.h"
 +
 +typedef enum eos_status {
@@ -148,6 +151,8 @@ index 0000000000..edddc01b8d
 +
 +    EbBufferHeaderType         *in_buf;
 +    int                         raw_size;
++
++    AVFrame *frame;
 +
 +    AVBufferPool* pool;
 +
@@ -352,6 +357,10 @@ index 0000000000..edddc01b8d
 +        goto failed_init_handle;
 +    }
 +
++    svt_enc->frame = av_frame_alloc();
++    if (!svt_enc->frame)
++        return AVERROR(ENOMEM);
++
 + //   if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
 + //       EbBufferHeaderType* headerPtr;
 + //       headerPtr->size       = sizeof(headerPtr);
@@ -403,6 +412,9 @@ index 0000000000..edddc01b8d
 +    EbBufferHeaderType  *headerPtr = svt_enc->in_buf;
 +
 +    if (!frame) {
++        if (svt_enc->eos_flag == EOS_REACHED)
++            return 0;
++
 +        EbBufferHeaderType headerPtrLast;
 +        headerPtrLast.n_alloc_len   = 0;
 +        headerPtrLast.n_filled_len  = 0;
@@ -446,12 +458,25 @@ index 0000000000..edddc01b8d
 +    SvtContext  *svt_enc = avctx->priv_data;
 +    EbBufferHeaderType   *headerPtr;
 +    EbErrorType          svt_ret;
++    AVFrame *frame = svt_enc->frame;
 +    AVBufferRef *ref;
++    int ret;
 +
 +    if (EOS_TOTRIGGER == svt_enc->eos_flag) {
 +        pkt = NULL;
 +        return AVERROR_EOF;
 +    }
++
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
++    ret = ff_encode_get_frame(avctx, frame);
++    if (ret < 0 && ret != AVERROR_EOF)
++        return ret;
++    if (ret == AVERROR_EOF)
++        frame = NULL;
++
++    eb_send_frame(avctx, frame);
++    av_frame_unref(svt_enc->frame);
++#endif
 +
 +    svt_ret = eb_vp9_svt_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
 +    if (svt_ret == EB_NoErrorEmptyQueue)
@@ -493,6 +518,8 @@ index 0000000000..edddc01b8d
 +
 +    eb_vp9_deinit_encoder(svt_enc->svt_handle);
 +    eb_vp9_deinit_handle(svt_enc->svt_handle);
++
++    av_frame_free(&svt_enc->frame);
 +
 +    free_buffer(svt_enc);
 +
@@ -571,7 +598,9 @@ index 0000000000..edddc01b8d
 +    .type           = AVMEDIA_TYPE_VIDEO,
 +    .id             = AV_CODEC_ID_VP9,
 +    .init           = eb_enc_init,
++#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 93, 100)
 +    .send_frame     = eb_send_frame,
++#endif
 +    .receive_packet = eb_receive_packet,
 +    .close          = eb_enc_close,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,
@@ -583,10 +612,10 @@ index 0000000000..edddc01b8d
 +    .wrapper_name   = "libsvt_vp9",
 +};
 diff --git a/libavformat/dashenc.c b/libavformat/dashenc.c
-index 3e587acdff..d1c6e65bdd 100644
+index 62193058d7..36c8e29250 100644
 --- a/libavformat/dashenc.c
 +++ b/libavformat/dashenc.c
-@@ -2259,6 +2259,48 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
+@@ -2267,6 +2267,48 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
      return ret;
  }
  
@@ -635,7 +664,7 @@ index 3e587acdff..d1c6e65bdd 100644
  static int dash_write_trailer(AVFormatContext *s)
  {
      DASHContext *c = s->priv_data;
-@@ -2306,6 +2348,11 @@ static int dash_check_bitstream(struct AVFormatContext *s, const AVPacket *avpkt
+@@ -2314,6 +2356,11 @@ static int dash_check_bitstream(struct AVFormatContext *s, const AVPacket *avpkt
      DASHContext *c = s->priv_data;
      OutputStream *os = &c->streams[avpkt->stream_index];
      AVFormatContext *oc = os->ctx;
@@ -647,7 +676,7 @@ index 3e587acdff..d1c6e65bdd 100644
      if (oc->oformat->check_bitstream) {
          int ret;
          AVPacket pkt = *avpkt;
-@@ -2392,7 +2439,7 @@ AVOutputFormat ff_dash_muxer = {
+@@ -2400,7 +2447,7 @@ AVOutputFormat ff_dash_muxer = {
      .flags          = AVFMT_GLOBALHEADER | AVFMT_NOFILE | AVFMT_TS_NEGATIVE,
      .init           = dash_init,
      .write_header   = dash_write_header,
@@ -698,7 +727,7 @@ index 0951f56c92..3a49097e9a 100644
          ctx->sum_delta_pts += pkt->pts - ctx->last_pts;
      ctx->frame_cnt++;
 diff --git a/libavformat/matroskaenc.c b/libavformat/matroskaenc.c
-index eaed02bc92..01d148ad18 100644
+index 105ed5197e..e4870227ab 100644
 --- a/libavformat/matroskaenc.c
 +++ b/libavformat/matroskaenc.c
 @@ -154,6 +154,8 @@ typedef struct MatroskaMuxContext {
@@ -725,7 +754,7 @@ index eaed02bc92..01d148ad18 100644
      avio_w8(pb, (blockid == MATROSKA_ID_SIMPLEBLOCK && keyframe) ? (1 << 7) : 0);
      avio_write(pb, data + offset, size);
      if (data != pkt->data)
-@@ -2268,7 +2276,7 @@ static int mkv_check_new_extra_data(AVFormatContext *s, const AVPacket *pkt)
+@@ -2266,7 +2274,7 @@ static int mkv_check_new_extra_data(AVFormatContext *s, const AVPacket *pkt)
      return 0;
  }
  
@@ -734,7 +763,7 @@ index eaed02bc92..01d148ad18 100644
  {
      MatroskaMuxContext *mkv = s->priv_data;
      AVIOContext *pb;
-@@ -2279,6 +2287,8 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
+@@ -2277,6 +2285,8 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
      int ret;
      int64_t ts = track->write_dts ? pkt->dts : pkt->pts;
      int64_t relative_packet_pos;
@@ -743,7 +772,7 @@ index eaed02bc92..01d148ad18 100644
  
      if (ts == AV_NOPTS_VALUE) {
          av_log(s, AV_LOG_ERROR, "Can't write packet with unknown timestamp\n");
-@@ -2296,12 +2306,23 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
+@@ -2294,12 +2304,23 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
          }
      }
  
@@ -768,7 +797,7 @@ index eaed02bc92..01d148ad18 100644
          mkv->cluster_pts = FFMAX(0, ts);
          av_log(s, AV_LOG_DEBUG,
                 "Starting new cluster with timestamp "
-@@ -2313,8 +2334,68 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
+@@ -2311,8 +2332,68 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
      relative_packet_pos = avio_tell(pb);
  
      if (par->codec_type != AVMEDIA_TYPE_SUBTITLE) {
@@ -839,7 +868,7 @@ index eaed02bc92..01d148ad18 100644
              return ret;
          if (keyframe && IS_SEEKABLE(s->pb, mkv) &&
              (par->codec_type == AVMEDIA_TYPE_VIDEO || !mkv->have_video && !track->has_cue)) {
-@@ -2360,7 +2441,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
+@@ -2358,7 +2439,7 @@ FF_ENABLE_DEPRECATION_WARNINGS
      return 0;
  }
  
@@ -848,7 +877,7 @@ index eaed02bc92..01d148ad18 100644
  {
      MatroskaMuxContext *mkv = s->priv_data;
      int codec_type          = s->streams[pkt->stream_index]->codecpar->codec_type;
-@@ -2377,8 +2458,13 @@ static int mkv_write_packet(AVFormatContext *s, const AVPacket *pkt)
+@@ -2375,8 +2456,13 @@ static int mkv_write_packet(AVFormatContext *s, const AVPacket *pkt)
      if (mkv->cluster_pos != -1) {
          if (mkv->tracks[pkt->stream_index].write_dts)
              cluster_time = pkt->dts - mkv->cluster_pts;
@@ -864,7 +893,7 @@ index eaed02bc92..01d148ad18 100644
          cluster_time += mkv->tracks[pkt->stream_index].ts_offset;
  
          cluster_size  = avio_tell(mkv->cluster_bc);
-@@ -2402,6 +2488,12 @@ static int mkv_write_packet(AVFormatContext *s, const AVPacket *pkt)
+@@ -2400,6 +2486,12 @@ static int mkv_write_packet(AVFormatContext *s, const AVPacket *pkt)
              start_new_cluster = 0;
  
          if (start_new_cluster) {
@@ -877,7 +906,7 @@ index eaed02bc92..01d148ad18 100644
              ret = mkv_end_cluster(s);
              if (ret < 0)
                  return ret;
-@@ -2739,6 +2831,10 @@ static int mkv_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
+@@ -2737,6 +2829,10 @@ static int mkv_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
      int ret = 1;
      AVStream *st = s->streams[pkt->stream_index];
  
@@ -889,10 +918,10 @@ index eaed02bc92..01d148ad18 100644
          if (pkt->size > 2 && (AV_RB16(pkt->data) & 0xfff0) == 0xfff0)
              ret = ff_stream_add_bitstream_filter(st, "aac_adtstoasc", NULL);
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index 520aaafb74..89b28516f1 100644
+index b8e45760ee..20f4c01293 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
-@@ -5837,7 +5837,42 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
+@@ -5841,7 +5841,42 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
          }
      }
  
@@ -936,7 +965,7 @@ index 520aaafb74..89b28516f1 100644
  }
  
  static int mov_write_subtitle_end_packet(AVFormatContext *s,
-@@ -6995,6 +7030,10 @@ static int mov_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
+@@ -6999,6 +7034,10 @@ static int mov_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
      int ret = 1;
      AVStream *st = s->streams[pkt->stream_index];
  

--- a/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch
+++ b/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch
@@ -1,4 +1,4 @@
-From 59d0c978dadbc67d347fcb075176d571d648d75f Mon Sep 17 00:00:00 2001
+From 03f81df8e369b68b299388a9aac8328611c5113a Mon Sep 17 00:00:00 2001
 From: hassene <hassene.tmar@intel.com>
 Date: Fri, 15 Feb 2019 17:43:54 -0800
 Subject: [PATCH 1/1] Add ability for ffmpeg to run svt vp9
@@ -12,12 +12,12 @@ Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
  libavcodec/Makefile       |   1 +
  libavcodec/allcodecs.c    |   1 +
  libavcodec/avcodec.h      |   4 +
- libavcodec/libsvt_vp9.c   | 482 ++++++++++++++++++++++++++++++++++++++
+ libavcodec/libsvt_vp9.c   | 511 ++++++++++++++++++++++++++++++++++++++
  libavformat/dashenc.c     |  49 +++-
  libavformat/ivfenc.c      |  30 ++-
  libavformat/matroskaenc.c | 103 +++++++-
  libavformat/movenc.c      |  42 +++-
- 9 files changed, 705 insertions(+), 11 deletions(-)
+ 9 files changed, 734 insertions(+), 11 deletions(-)
  create mode 100644 libavcodec/libsvt_vp9.c
 
 diff --git a/configure b/configure
@@ -97,10 +97,10 @@ index c91b2fd169..10cdb7b0d9 100644
   * Export the AVVideoEncParams structure through frame side data.
 diff --git a/libavcodec/libsvt_vp9.c b/libavcodec/libsvt_vp9.c
 new file mode 100644
-index 0000000000..edddc01b8d
+index 0000000000..35498f3a77
 --- /dev/null
 +++ b/libavcodec/libsvt_vp9.c
-@@ -0,0 +1,482 @@
+@@ -0,0 +1,511 @@
 +/*
 +* Scalable Video Technology for VP9 encoder library plugin
 +*
@@ -133,6 +133,9 @@ index 0000000000..edddc01b8d
 +#include "libavutil/opt.h"
 +
 +#include "internal.h"
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
++#include "encode.h"
++#endif
 +#include "avcodec.h"
 +
 +typedef enum eos_status {
@@ -149,6 +152,8 @@ index 0000000000..edddc01b8d
 +
 +    EbBufferHeaderType         *in_buf;
 +    int                         raw_size;
++
++    AVFrame *frame;
 +
 +    AVBufferPool* pool;
 +
@@ -353,6 +358,10 @@ index 0000000000..edddc01b8d
 +        goto failed_init_handle;
 +    }
 +
++    svt_enc->frame = av_frame_alloc();
++    if (!svt_enc->frame)
++        return AVERROR(ENOMEM);
++
 + //   if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
 + //       EbBufferHeaderType* headerPtr;
 + //       headerPtr->size       = sizeof(headerPtr);
@@ -404,6 +413,9 @@ index 0000000000..edddc01b8d
 +    EbBufferHeaderType  *headerPtr = svt_enc->in_buf;
 +
 +    if (!frame) {
++        if (svt_enc->eos_flag == EOS_REACHED)
++            return 0;
++
 +        EbBufferHeaderType headerPtrLast;
 +        headerPtrLast.n_alloc_len   = 0;
 +        headerPtrLast.n_filled_len  = 0;
@@ -447,12 +459,25 @@ index 0000000000..edddc01b8d
 +    SvtContext  *svt_enc = avctx->priv_data;
 +    EbBufferHeaderType   *headerPtr;
 +    EbErrorType          svt_ret;
++    AVFrame *frame = svt_enc->frame;
 +    AVBufferRef *ref;
++    int ret;
 +
 +    if (EOS_TOTRIGGER == svt_enc->eos_flag) {
 +        pkt = NULL;
 +        return AVERROR_EOF;
 +    }
++
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
++    ret = ff_encode_get_frame(avctx, frame);
++    if (ret < 0 && ret != AVERROR_EOF)
++        return ret;
++    if (ret == AVERROR_EOF)
++        frame = NULL;
++
++    eb_send_frame(avctx, frame);
++    av_frame_unref(svt_enc->frame);
++#endif
 +
 +    svt_ret = eb_vp9_svt_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
 +    if (svt_ret == EB_NoErrorEmptyQueue)
@@ -494,6 +519,8 @@ index 0000000000..edddc01b8d
 +
 +    eb_vp9_deinit_encoder(svt_enc->svt_handle);
 +    eb_vp9_deinit_handle(svt_enc->svt_handle);
++
++    av_frame_free(&svt_enc->frame);
 +
 +    free_buffer(svt_enc);
 +
@@ -572,7 +599,9 @@ index 0000000000..edddc01b8d
 +    .type           = AVMEDIA_TYPE_VIDEO,
 +    .id             = AV_CODEC_ID_VP9,
 +    .init           = eb_enc_init,
++#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 93, 100)
 +    .send_frame     = eb_send_frame,
++#endif
 +    .receive_packet = eb_receive_packet,
 +    .close          = eb_enc_close,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,
@@ -584,10 +613,10 @@ index 0000000000..edddc01b8d
 +    .wrapper_name   = "libsvt_vp9",
 +};
 diff --git a/libavformat/dashenc.c b/libavformat/dashenc.c
-index 3e587acdff..d1c6e65bdd 100644
+index 62193058d7..36c8e29250 100644
 --- a/libavformat/dashenc.c
 +++ b/libavformat/dashenc.c
-@@ -2259,6 +2259,48 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
+@@ -2267,6 +2267,48 @@ static int dash_write_packet(AVFormatContext *s, AVPacket *pkt)
      return ret;
  }
  
@@ -636,7 +665,7 @@ index 3e587acdff..d1c6e65bdd 100644
  static int dash_write_trailer(AVFormatContext *s)
  {
      DASHContext *c = s->priv_data;
-@@ -2306,6 +2348,11 @@ static int dash_check_bitstream(struct AVFormatContext *s, const AVPacket *avpkt
+@@ -2314,6 +2356,11 @@ static int dash_check_bitstream(struct AVFormatContext *s, const AVPacket *avpkt
      DASHContext *c = s->priv_data;
      OutputStream *os = &c->streams[avpkt->stream_index];
      AVFormatContext *oc = os->ctx;
@@ -648,7 +677,7 @@ index 3e587acdff..d1c6e65bdd 100644
      if (oc->oformat->check_bitstream) {
          int ret;
          AVPacket pkt = *avpkt;
-@@ -2392,7 +2439,7 @@ AVOutputFormat ff_dash_muxer = {
+@@ -2400,7 +2447,7 @@ AVOutputFormat ff_dash_muxer = {
      .flags          = AVFMT_GLOBALHEADER | AVFMT_NOFILE | AVFMT_TS_NEGATIVE,
      .init           = dash_init,
      .write_header   = dash_write_header,
@@ -699,7 +728,7 @@ index 0951f56c92..3a49097e9a 100644
          ctx->sum_delta_pts += pkt->pts - ctx->last_pts;
      ctx->frame_cnt++;
 diff --git a/libavformat/matroskaenc.c b/libavformat/matroskaenc.c
-index eaed02bc92..71bf8da663 100644
+index 105ed5197e..b625d405a6 100644
 --- a/libavformat/matroskaenc.c
 +++ b/libavformat/matroskaenc.c
 @@ -154,6 +154,8 @@ typedef struct MatroskaMuxContext {
@@ -726,7 +755,7 @@ index eaed02bc92..71bf8da663 100644
      avio_w8(pb, (blockid == MATROSKA_ID_SIMPLEBLOCK && keyframe) ? (1 << 7) : 0);
      avio_write(pb, data + offset, size);
      if (data != pkt->data)
-@@ -2268,7 +2276,7 @@ static int mkv_check_new_extra_data(AVFormatContext *s, const AVPacket *pkt)
+@@ -2266,7 +2274,7 @@ static int mkv_check_new_extra_data(AVFormatContext *s, const AVPacket *pkt)
      return 0;
  }
  
@@ -735,7 +764,7 @@ index eaed02bc92..71bf8da663 100644
  {
      MatroskaMuxContext *mkv = s->priv_data;
      AVIOContext *pb;
-@@ -2279,6 +2287,8 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
+@@ -2277,6 +2285,8 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
      int ret;
      int64_t ts = track->write_dts ? pkt->dts : pkt->pts;
      int64_t relative_packet_pos;
@@ -744,7 +773,7 @@ index eaed02bc92..71bf8da663 100644
  
      if (ts == AV_NOPTS_VALUE) {
          av_log(s, AV_LOG_ERROR, "Can't write packet with unknown timestamp\n");
-@@ -2296,6 +2306,11 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
+@@ -2294,6 +2304,11 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
          }
      }
  
@@ -756,7 +785,7 @@ index eaed02bc92..71bf8da663 100644
      if (mkv->cluster_pos == -1) {
          ret = start_ebml_master_crc32(&mkv->cluster_bc, mkv);
          if (ret < 0)
-@@ -2313,7 +2328,67 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
+@@ -2311,7 +2326,67 @@ static int mkv_write_packet_internal(AVFormatContext *s, const AVPacket *pkt)
      relative_packet_pos = avio_tell(pb);
  
      if (par->codec_type != AVMEDIA_TYPE_SUBTITLE) {
@@ -825,7 +854,7 @@ index eaed02bc92..71bf8da663 100644
          if (ret < 0)
              return ret;
          if (keyframe && IS_SEEKABLE(s->pb, mkv) &&
-@@ -2377,8 +2452,14 @@ static int mkv_write_packet(AVFormatContext *s, const AVPacket *pkt)
+@@ -2375,8 +2450,14 @@ static int mkv_write_packet(AVFormatContext *s, const AVPacket *pkt)
      if (mkv->cluster_pos != -1) {
          if (mkv->tracks[pkt->stream_index].write_dts)
              cluster_time = pkt->dts - mkv->cluster_pts;
@@ -842,7 +871,7 @@ index eaed02bc92..71bf8da663 100644
          cluster_time += mkv->tracks[pkt->stream_index].ts_offset;
  
          cluster_size  = avio_tell(mkv->cluster_bc);
-@@ -2402,7 +2483,13 @@ static int mkv_write_packet(AVFormatContext *s, const AVPacket *pkt)
+@@ -2400,7 +2481,13 @@ static int mkv_write_packet(AVFormatContext *s, const AVPacket *pkt)
              start_new_cluster = 0;
  
          if (start_new_cluster) {
@@ -857,7 +886,7 @@ index eaed02bc92..71bf8da663 100644
              if (ret < 0)
                  return ret;
          }
-@@ -2739,6 +2826,10 @@ static int mkv_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
+@@ -2737,6 +2824,10 @@ static int mkv_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
      int ret = 1;
      AVStream *st = s->streams[pkt->stream_index];
  
@@ -869,10 +898,10 @@ index eaed02bc92..71bf8da663 100644
          if (pkt->size > 2 && (AV_RB16(pkt->data) & 0xfff0) == 0xfff0)
              ret = ff_stream_add_bitstream_filter(st, "aac_adtstoasc", NULL);
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index 520aaafb74..de73def6f1 100644
+index b8e45760ee..fcc77a46a2 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
-@@ -5837,7 +5837,43 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
+@@ -5841,7 +5841,43 @@ static int mov_write_single_packet(AVFormatContext *s, AVPacket *pkt)
          }
      }
  
@@ -917,7 +946,7 @@ index 520aaafb74..de73def6f1 100644
  }
  
  static int mov_write_subtitle_end_packet(AVFormatContext *s,
-@@ -6995,6 +7031,10 @@ static int mov_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
+@@ -6999,6 +7035,10 @@ static int mov_check_bitstream(struct AVFormatContext *s, const AVPacket *pkt)
      int ret = 1;
      AVStream *st = s->streams[pkt->stream_index];
  

--- a/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch
+++ b/ffmpeg_plugin/master-0001-Add-ability-for-ffmpeg-to-run-svt-vp9.patch
@@ -1,4 +1,4 @@
-From 03f81df8e369b68b299388a9aac8328611c5113a Mon Sep 17 00:00:00 2001
+From 0bae1a68db540821974e35595f909fb9b8f08e9d Mon Sep 17 00:00:00 2001
 From: hassene <hassene.tmar@intel.com>
 Date: Fri, 15 Feb 2019 17:43:54 -0800
 Subject: [PATCH 1/1] Add ability for ffmpeg to run svt vp9
@@ -12,12 +12,12 @@ Signed-off-by: Guo Jiansheng <jiansheng.guo@intel.com>
  libavcodec/Makefile       |   1 +
  libavcodec/allcodecs.c    |   1 +
  libavcodec/avcodec.h      |   4 +
- libavcodec/libsvt_vp9.c   | 511 ++++++++++++++++++++++++++++++++++++++
+ libavcodec/libsvt_vp9.c   | 504 ++++++++++++++++++++++++++++++++++++++
  libavformat/dashenc.c     |  49 +++-
  libavformat/ivfenc.c      |  30 ++-
  libavformat/matroskaenc.c | 103 +++++++-
  libavformat/movenc.c      |  42 +++-
- 9 files changed, 734 insertions(+), 11 deletions(-)
+ 9 files changed, 727 insertions(+), 11 deletions(-)
  create mode 100644 libavcodec/libsvt_vp9.c
 
 diff --git a/configure b/configure
@@ -97,10 +97,10 @@ index c91b2fd169..10cdb7b0d9 100644
   * Export the AVVideoEncParams structure through frame side data.
 diff --git a/libavcodec/libsvt_vp9.c b/libavcodec/libsvt_vp9.c
 new file mode 100644
-index 0000000000..35498f3a77
+index 0000000000..6bd6243de0
 --- /dev/null
 +++ b/libavcodec/libsvt_vp9.c
-@@ -0,0 +1,511 @@
+@@ -0,0 +1,504 @@
 +/*
 +* Scalable Video Technology for VP9 encoder library plugin
 +*
@@ -133,9 +133,7 @@ index 0000000000..35498f3a77
 +#include "libavutil/opt.h"
 +
 +#include "internal.h"
-+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
 +#include "encode.h"
-+#endif
 +#include "avcodec.h"
 +
 +typedef enum eos_status {
@@ -468,7 +466,6 @@ index 0000000000..35498f3a77
 +        return AVERROR_EOF;
 +    }
 +
-+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
 +    ret = ff_encode_get_frame(avctx, frame);
 +    if (ret < 0 && ret != AVERROR_EOF)
 +        return ret;
@@ -477,7 +474,6 @@ index 0000000000..35498f3a77
 +
 +    eb_send_frame(avctx, frame);
 +    av_frame_unref(svt_enc->frame);
-+#endif
 +
 +    svt_ret = eb_vp9_svt_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
 +    if (svt_ret == EB_NoErrorEmptyQueue)
@@ -599,9 +595,6 @@ index 0000000000..35498f3a77
 +    .type           = AVMEDIA_TYPE_VIDEO,
 +    .id             = AV_CODEC_ID_VP9,
 +    .init           = eb_enc_init,
-+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 93, 100)
-+    .send_frame     = eb_send_frame,
-+#endif
 +    .receive_packet = eb_receive_packet,
 +    .close          = eb_enc_close,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,


### PR DESCRIPTION
https://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=827d6fe73d2f5472c1c2128eb14fab6a4db29032 changed the internal encode API, as as such the ffmpeg plugin needs to be adapted.

Without this change, the plugin will fail to build starting with lavc version 58.93.100

Fixes #118