### PR TITLE
Specific Resolution Fix

### DIFF
--- a/Source/Lib/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Codec/EbEntropyCodingProcess.c
@@ -57,6 +57,7 @@ EbErrorType eb_vp9_entropy_coding_context_ctor(
 
     return EB_ErrorNone;
 }
+int g_block_index = 0;
 
 /**********************************************
 * Entropy Coding SB
@@ -80,7 +81,6 @@ EbErrorType EntropyCodingSb(
     uint32_t                  block_index = 0;
     uint32_t                  rasterScanIndex;
     uint32_t                  valid_block_index;
-    uint32_t                  search_valid_index;
 
     // Set mi_grid_visible
     cm->mi_grid_visible = picture_control_set_ptr->mode_info_array;
@@ -126,18 +126,12 @@ EbErrorType EntropyCodingSb(
         context_ptr->mi_row = context_ptr->block_origin_y >> MI_SIZE_LOG2;
 
         // Derive partition using block validity and split_flag
-        PARTITION_TYPE partition;
-        valid_block_index = (uint32_t) ~0;
-        for (search_valid_index = block_index; search_valid_index < (block_index + ep_inter_depth_offset); search_valid_index++) {
-            if (search_valid_index < EP_BLOCK_MAX_COUNT && (EB_BOOL)lcuParam->ep_scan_block_validity[search_valid_index] == EB_TRUE) {
-                valid_block_index = search_valid_index;
-                break;
-            }
-        }
+		// ep_scan_block_valid_block holds the block index for the first valid block/subblock
+		// covered by the block (at any depth).  A block is valid if it is within the frame boundary.
+		valid_block_index = lcuParam->ep_scan_block_valid_block[block_index];
 
-        if (valid_block_index == (uint32_t)~0 && ((EB_BOOL)lcuParam->ep_scan_block_validity[search_valid_index + 1] == EB_TRUE)) {
-            partition = PARTITION_SPLIT;
-        } else if (valid_block_index == (uint32_t)~0) {
+		PARTITION_TYPE partition;
+		if (valid_block_index == (uint32_t)~0) {
             partition = PARTITION_INVALID;
         }
         else {

--- a/Source/Lib/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Codec/EbEntropyCodingProcess.c
@@ -57,7 +57,6 @@ EbErrorType eb_vp9_entropy_coding_context_ctor(
 
     return EB_ErrorNone;
 }
-int g_block_index = 0;
 
 /**********************************************
 * Entropy Coding SB
@@ -126,12 +125,12 @@ EbErrorType EntropyCodingSb(
         context_ptr->mi_row = context_ptr->block_origin_y >> MI_SIZE_LOG2;
 
         // Derive partition using block validity and split_flag
-		// ep_scan_block_valid_block holds the block index for the first valid block/subblock
-		// covered by the block (at any depth).  A block is valid if it is within the frame boundary.
-		valid_block_index = lcuParam->ep_scan_block_valid_block[block_index];
+        // ep_scan_block_valid_block holds the block index for the first valid block/subblock
+        // covered by the block (at any depth).  A block is valid if it is within the frame boundary.
+        valid_block_index = lcuParam->ep_scan_block_valid_block[block_index];
 
-		PARTITION_TYPE partition;
-		if (valid_block_index == (uint32_t)~0) {
+        PARTITION_TYPE partition;
+        if (valid_block_index == (uint32_t)~0) {
             partition = PARTITION_INVALID;
         }
         else {

--- a/Source/Lib/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Codec/EbEntropyCodingProcess.c
@@ -125,9 +125,9 @@ EbErrorType EntropyCodingSb(
         context_ptr->mi_row = context_ptr->block_origin_y >> MI_SIZE_LOG2;
 
         // Derive partition using block validity and split_flag
-        // ep_scan_block_valid_block holds the block index for the first valid block/subblock
+        // ec_scan_block_valid_block holds the block index for the first valid block/subblock
         // covered by the block (at any depth).  A block is valid if it is within the frame boundary.
-        valid_block_index = lcuParam->ep_scan_block_valid_block[block_index];
+        valid_block_index = lcuParam->ec_scan_block_valid_block[block_index];
 
         PARTITION_TYPE partition;
         if (valid_block_index == (uint16_t)~0) {

--- a/Source/Lib/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Codec/EbEntropyCodingProcess.c
@@ -79,7 +79,7 @@ EbErrorType EntropyCodingSb(
 
     uint32_t                  block_index = 0;
     uint32_t                  rasterScanIndex;
-    uint32_t                  valid_block_index;
+    uint16_t                  valid_block_index;
 
     // Set mi_grid_visible
     cm->mi_grid_visible = picture_control_set_ptr->mode_info_array;
@@ -130,7 +130,7 @@ EbErrorType EntropyCodingSb(
         valid_block_index = lcuParam->ep_scan_block_valid_block[block_index];
 
         PARTITION_TYPE partition;
-        if (valid_block_index == (uint32_t)~0) {
+        if (valid_block_index == (uint16_t)~0) {
             partition = PARTITION_INVALID;
         }
         else {

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -193,7 +193,7 @@ typedef struct SbParameters
     uint8_t   is_complete_sb;
     EB_BOOL   pa_raster_scan_block_validity[PA_BLOCK_MAX_COUNT];
     EB_BOOL   ep_scan_block_validity[EP_BLOCK_MAX_COUNT];
-    uint32_t  ep_scan_block_valid_block[EP_BLOCK_MAX_COUNT];
+    uint16_t  ep_scan_block_valid_block[EP_BLOCK_MAX_COUNT];
     uint8_t   potential_logo_sb;
     uint8_t   is_edge_sb;
 } SbParams;

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -193,7 +193,7 @@ typedef struct SbParameters
     uint8_t   is_complete_sb;
     EB_BOOL   pa_raster_scan_block_validity[PA_BLOCK_MAX_COUNT];
     EB_BOOL   ep_scan_block_validity[EP_BLOCK_MAX_COUNT];
-	uint32_t  ep_scan_block_valid_block[EP_BLOCK_MAX_COUNT];
+    uint32_t  ep_scan_block_valid_block[EP_BLOCK_MAX_COUNT];
     uint8_t   potential_logo_sb;
     uint8_t   is_edge_sb;
 } SbParams;

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -193,6 +193,7 @@ typedef struct SbParameters
     uint8_t   is_complete_sb;
     EB_BOOL   pa_raster_scan_block_validity[PA_BLOCK_MAX_COUNT];
     EB_BOOL   ep_scan_block_validity[EP_BLOCK_MAX_COUNT];
+	uint32_t  ep_scan_block_valid_block[EP_BLOCK_MAX_COUNT];
     uint8_t   potential_logo_sb;
     uint8_t   is_edge_sb;
 } SbParams;

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -193,7 +193,7 @@ typedef struct SbParameters
     uint8_t   is_complete_sb;
     EB_BOOL   pa_raster_scan_block_validity[PA_BLOCK_MAX_COUNT];
     EB_BOOL   ep_scan_block_validity[EP_BLOCK_MAX_COUNT];
-    uint16_t  ep_scan_block_valid_block[EP_BLOCK_MAX_COUNT];
+    uint16_t  ec_scan_block_valid_block[EP_BLOCK_MAX_COUNT];
     uint8_t   potential_logo_sb;
     uint8_t   is_edge_sb;
 } SbParams;

--- a/Source/Lib/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Codec/EbSequenceControlSet.c
@@ -366,7 +366,7 @@ extern EbErrorType eb_vp9_sb_params_init(
                 EB_FALSE :
                 EB_TRUE;
 
-           sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint32_t)~0;
+           sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint16_t)~0;
         }
 
         // Find the valid block for each block (highest depth block which is valid and covered by this block). 
@@ -375,7 +375,7 @@ extern EbErrorType eb_vp9_sb_params_init(
         for (md_scan_block_index = EP_BLOCK_MAX_COUNT - 1; md_scan_block_index-- != 0; )
         {
             // Initialize the valid block
-            sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint32_t)~0;
+            sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint16_t)~0;
 
             // If this block is valid, set it as the valid block.
             if (sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_validity[md_scan_block_index] == EB_TRUE)
@@ -388,8 +388,8 @@ extern EbErrorType eb_vp9_sb_params_init(
                 if (ep_block_stats_ptr->bsize > 3)
                 {
                     // Check all of the blocks at the lower depth and find the first one that is valid.
-                    for (int search_valid_index = md_scan_block_index; search_valid_index < (md_scan_block_index + ep_inter_depth_offset); search_valid_index++) {
-                        if (search_valid_index < EP_BLOCK_MAX_COUNT && sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index] != (uint32_t)~0) {
+                    for (uint16_t search_valid_index = md_scan_block_index; search_valid_index < (md_scan_block_index + ep_inter_depth_offset); search_valid_index++) {
+                        if (search_valid_index < EP_BLOCK_MAX_COUNT && sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index] != (uint16_t)~0) {
                             sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index];
                             break;
                         }

--- a/Source/Lib/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Codec/EbSequenceControlSet.c
@@ -365,7 +365,38 @@ extern EbErrorType eb_vp9_sb_params_init(
             sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_validity[md_scan_block_index] = (((sequence_control_set_ptr->sb_params_array[sb_index].origin_x + ep_block_stats_ptr->origin_x + ep_block_stats_ptr->bwidth) > sequence_control_set_ptr->luma_width) || ((sequence_control_set_ptr->sb_params_array[sb_index].origin_y + ep_block_stats_ptr->origin_y + ep_block_stats_ptr->bheight) > sequence_control_set_ptr->luma_height)) ?
                 EB_FALSE :
                 EB_TRUE;
+
+			sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint32_t)~0;
         }
+
+		// Find the valid block for each block (highest depth block which is valid and covered by this block). 
+		// A valid block is a block that is within the boundaries of the frame.
+		// Note: The unsigned int loop index logic will go from EP_BLOCK_MAX_COUNT-1 to and including 0.
+		for (md_scan_block_index = EP_BLOCK_MAX_COUNT - 1; md_scan_block_index-- != 0; )
+		{
+			// Initialize the valid block
+			sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint32_t)~0;
+
+			// If this block is valid, set it as the valid block.
+			if (sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_validity[md_scan_block_index] == EB_TRUE)
+				sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = md_scan_block_index;
+			else{
+				// search the next lowest depth for valid blocks, but don't go lower than 8x8
+				const EpBlockStats *ep_block_stats_ptr = ep_get_block_stats(md_scan_block_index);
+
+				// Only search when block size is greater than 8x8
+				if (ep_block_stats_ptr->bsize > 3)
+				{
+					// Check all of the blocks at the lower depth and find the first one that is valid.
+					for (int search_valid_index = md_scan_block_index; search_valid_index < (md_scan_block_index + ep_inter_depth_offset); search_valid_index++) {
+						if (search_valid_index < EP_BLOCK_MAX_COUNT && sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index] != (uint32_t)~0) {
+							sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index];
+							break;
+						}
+					}
+				}
+			}
+		}
     }
 
     sequence_control_set_ptr->picture_width_in_sb = picturesb_width;

--- a/Source/Lib/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Codec/EbSequenceControlSet.c
@@ -366,7 +366,7 @@ extern EbErrorType eb_vp9_sb_params_init(
                 EB_FALSE :
                 EB_TRUE;
 
-           sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint16_t)~0;
+           sequence_control_set_ptr->sb_params_array[sb_index].ec_scan_block_valid_block[md_scan_block_index] = (uint16_t)~0;
         }
 
         // Find the valid block for each block (highest depth block which is valid and covered by this block). 
@@ -375,11 +375,11 @@ extern EbErrorType eb_vp9_sb_params_init(
         for (md_scan_block_index = EP_BLOCK_MAX_COUNT - 1; md_scan_block_index-- != 0; )
         {
             // Initialize the valid block
-            sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint16_t)~0;
+            sequence_control_set_ptr->sb_params_array[sb_index].ec_scan_block_valid_block[md_scan_block_index] = (uint16_t)~0;
 
             // If this block is valid, set it as the valid block.
             if (sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_validity[md_scan_block_index] == EB_TRUE)
-                sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = md_scan_block_index;
+                sequence_control_set_ptr->sb_params_array[sb_index].ec_scan_block_valid_block[md_scan_block_index] = md_scan_block_index;
             else{
                 // search the next lowest depth for valid blocks, but don't go lower than 8x8
                 const EpBlockStats *ep_block_stats_ptr = ep_get_block_stats(md_scan_block_index);
@@ -389,8 +389,8 @@ extern EbErrorType eb_vp9_sb_params_init(
                 {
                     // Check all of the blocks at the lower depth and find the first one that is valid.
                     for (uint16_t search_valid_index = md_scan_block_index; search_valid_index < (md_scan_block_index + ep_inter_depth_offset); search_valid_index++) {
-                        if (search_valid_index < EP_BLOCK_MAX_COUNT && sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index] != (uint16_t)~0) {
-                            sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index];
+                        if (search_valid_index < EP_BLOCK_MAX_COUNT && sequence_control_set_ptr->sb_params_array[sb_index].ec_scan_block_valid_block[search_valid_index] != (uint16_t)~0) {
+                            sequence_control_set_ptr->sb_params_array[sb_index].ec_scan_block_valid_block[md_scan_block_index] = sequence_control_set_ptr->sb_params_array[sb_index].ec_scan_block_valid_block[search_valid_index];
                             break;
                         }
                     }

--- a/Source/Lib/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Codec/EbSequenceControlSet.c
@@ -366,37 +366,37 @@ extern EbErrorType eb_vp9_sb_params_init(
                 EB_FALSE :
                 EB_TRUE;
 
-			sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint32_t)~0;
+           sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint32_t)~0;
         }
 
-		// Find the valid block for each block (highest depth block which is valid and covered by this block). 
-		// A valid block is a block that is within the boundaries of the frame.
-		// Note: The unsigned int loop index logic will go from EP_BLOCK_MAX_COUNT-1 to and including 0.
-		for (md_scan_block_index = EP_BLOCK_MAX_COUNT - 1; md_scan_block_index-- != 0; )
-		{
-			// Initialize the valid block
-			sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint32_t)~0;
+        // Find the valid block for each block (highest depth block which is valid and covered by this block). 
+        // A valid block is a block that is within the boundaries of the frame.
+        // Note: The unsigned int loop index logic will go from EP_BLOCK_MAX_COUNT-1 to and including 0.
+        for (md_scan_block_index = EP_BLOCK_MAX_COUNT - 1; md_scan_block_index-- != 0; )
+        {
+            // Initialize the valid block
+            sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = (uint32_t)~0;
 
-			// If this block is valid, set it as the valid block.
-			if (sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_validity[md_scan_block_index] == EB_TRUE)
-				sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = md_scan_block_index;
-			else{
-				// search the next lowest depth for valid blocks, but don't go lower than 8x8
-				const EpBlockStats *ep_block_stats_ptr = ep_get_block_stats(md_scan_block_index);
+            // If this block is valid, set it as the valid block.
+            if (sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_validity[md_scan_block_index] == EB_TRUE)
+                sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = md_scan_block_index;
+            else{
+                // search the next lowest depth for valid blocks, but don't go lower than 8x8
+                const EpBlockStats *ep_block_stats_ptr = ep_get_block_stats(md_scan_block_index);
 
-				// Only search when block size is greater than 8x8
-				if (ep_block_stats_ptr->bsize > 3)
-				{
-					// Check all of the blocks at the lower depth and find the first one that is valid.
-					for (int search_valid_index = md_scan_block_index; search_valid_index < (md_scan_block_index + ep_inter_depth_offset); search_valid_index++) {
-						if (search_valid_index < EP_BLOCK_MAX_COUNT && sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index] != (uint32_t)~0) {
-							sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index];
-							break;
-						}
-					}
-				}
-			}
-		}
+                // Only search when block size is greater than 8x8
+                if (ep_block_stats_ptr->bsize > 3)
+                {
+                    // Check all of the blocks at the lower depth and find the first one that is valid.
+                    for (int search_valid_index = md_scan_block_index; search_valid_index < (md_scan_block_index + ep_inter_depth_offset); search_valid_index++) {
+                        if (search_valid_index < EP_BLOCK_MAX_COUNT && sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index] != (uint32_t)~0) {
+                            sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[md_scan_block_index] = sequence_control_set_ptr->sb_params_array[sb_index].ep_scan_block_valid_block[search_valid_index];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     sequence_control_set_ptr->picture_width_in_sb = picturesb_width;


### PR DESCRIPTION
Fixed an issue that arose when frame sizes were non standard sized.
(e.g. non multiples of the largest coding unit (lcu) (64x64)).
For the example below the frame size used is 104x64. Encoded frames
showed a visible artifact.  In other cases, the frame could not be
successfully decoded by VQ Analyzer.

Root cause of the problem was in the logic that determined if the
current block to be coded contained a valid block (one which is fully
inside the frame).  If it did not contain a valid block, the current
block would be considered invalid and thus not coded.

The previous logic only checked the current block and blocks at
the next lowest depth for valid blocks.  However for certain sizes
(e.g. 104x64) some blocks require that a lower depth be searched
for valid blocks.

In this example, the 32x32 block at pixel location (96,0) was declared
invalid since itself and the 4 16x16 blocks it covers were all
invalid:
(96,0) 16x16 - invalid
(112,0) 16x16 - invalid
(96,16) 16x16- invalid
(112,16) 16x16 - invalid

However at the 8x8 depth there are indeed blocks that are valid:
(96,0) 8x8 - valid
(96,8) 8x8 - valid
(96,16) 8x8 - valid
(96,24) 8x8 - valid
etc...

One possible solution would be to expand the logic in the entropy
coding logic to recursively check blocks at lower levels, however 
this might be too messy.  Also since this logic is executed
for every superblock on every frame, a better solution would be
to predetermine a valid block index for ever block in the superblock
once and store the results in an array.

Added a ep_scan_block_valid_block array similar to the
ep_scan_block_validity array in the SbParameters structure.

This array gets populated when the super block is initialized in
eb_vp9_sb_params_init.  The logic to initialize the array is to
iterate through the blocks (smallest to largest). The
valid block index for the current block is determined by examining only
that block and the 4 blocks it covers at a single lower depth.  If any
of those blocks are valid, then that block is recorded for the valid
block at the current block.

Predetermining the valid blocks should be a bit more efficient allowing
for a single array lookup, rather than a iterating through a loop
with 5 (ep_inter_depth_offset) comparison checks.

This PR fixes: https://github.com/OpenVisualCloud/SVT-VP9/issues/85
Incorrect encoded bitstream with some specific resolutions (such as
360x360)