### PR TITLE
Fixed build with GCC 11 by moving MSVC flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,11 +119,9 @@ set(flags_to_test
     -fPIC
     -D_FORTIFY_SOURCE=2
     #-flto
-    -fvisibility=hidden
-    /GS
-    /sdl)
+    -fvisibility=hidden)
 if(MSVC)
-    list(APPEND flags_to_test /MP)
+    list(APPEND flags_to_test /MP /GS /sdl)
 else()
     option(NATIVE "Build for native performance (march=native)")
     list(INSERT flags_to_test 0 -Wall)


### PR DESCRIPTION
Fixed build with GCC 11 by moving MSVC flags:

```
-- Performing Test C_FLAG_sdl
-- Performing Test C_FLAG_sdl - Failed
-- Performing Test C_FLAG_fstack_protector_strong
-- Performing Test C_FLAG_fstack_protector_strong - Failed
-- Performing Test C_FLAG_msse2
-- Performing Test C_FLAG_msse2 - Failed
-- Performing Test C_FLAG_mssse3
-- Performing Test C_FLAG_mssse3 - Failed
-- Performing Test C_FLAG_msse4_1
-- Performing Test C_FLAG_msse4_1 - Failed
-- Performing Test C_FLAG_mavx2
-- Performing Test C_FLAG_mavx2 - Failed
gcc: warning: /GS: linker input file unused because linking not done
```

Closes #132.