### PR TITLE
Avoid name conflict on `log2f64` from `math.h`

### DIFF
--- a/Source/Lib/Codec/EbUtility.c
+++ b/Source/Lib/Codec/EbUtility.c
@@ -127,7 +127,7 @@ PaBlockStats  * pa_get_block_stats(int block_index)
  *  Leading Zeros (NLZ) algorithm to get
  *  the log2f of a 64-bit number
  *****************************************/
-inline uint64_t log2f64(uint64_t x)
+inline uint64_t Log2f64(uint64_t x)
 {
     uint64_t y;
     int64_t n = 64, c = 32;
@@ -163,7 +163,7 @@ uint32_t eb_vp9_endian_swap(uint32_t ui)
 uint64_t eb_vp9_log2f_high_precision(uint64_t x, uint8_t precision)
 {
 
-    uint64_t sig_bit_location = log2f64(x);
+    uint64_t sig_bit_location = Log2f64(x);
     uint64_t remainder = x - ((uint64_t)1 << (uint8_t) sig_bit_location);
     uint64_t result;
 

--- a/Source/Lib/Codec/EbUtility.h
+++ b/Source/Lib/Codec/EbUtility.h
@@ -92,7 +92,7 @@ extern PaBlockStats *pa_get_block_stats(int block_index);
 const  EpBlockStats *ep_get_block_stats(uint32_t bidx_mds);
 
 extern uint32_t Log2f(uint32_t x);
-extern uint64_t log2f64(uint64_t x);
+extern uint64_t Log2f64(uint64_t x);
 extern uint32_t eb_vp9_endian_swap(uint32_t ui);
 extern uint64_t eb_vp9_log2f_high_precision(uint64_t x, uint8_t precision);
 /****************************


### PR DESCRIPTION
Avoid name conflict on `log2f64` function name from `math.h` system header on Ubuntu 18+:
```
Source/Lib/Codec/EbUtility.h:95:17: error: conflicting types for 'log2f64'
extern uint64_t log2f64(uint64_t x);
                ^
/usr/include/x86_64-linux-gnu/bits/mathcalls.h:133:1: note: previous declaration is here
__MATHCALL (log2,, (_Mdouble_ __x));
^
/usr/include/math.h:273:3: note: expanded from macro '__MATHCALL'
  __MATHDECL (_Mdouble_,function,suffix, args)
  ^
/usr/include/math.h:275:3: note: expanded from macro '__MATHDECL'
  __MATHDECL_1(type, function,suffix, args); \
  ^
/usr/include/math.h:283:15: note: expanded from macro '__MATHDECL_1'
  extern type __MATH_PRECNAME(function,suffix) args __THROW
              ^
/usr/include/math.h:399:34: note: expanded from macro '__MATH_PRECNAME'
# define __MATH_PRECNAME(name,r) name##f64##r
                                 ^
<scratch space>:301:1: note: expanded from here
log2f64
```