### PR TITLE
Fix difference between -asm 0 and -asm 1 output

### DIFF
--- a/Source/Lib/Codec/EbComputeSAD.h
+++ b/Source/Lib/Codec/EbComputeSAD.h
@@ -154,12 +154,14 @@ extern "C" {
         eb_vp9_get_eight_horizontal_search_point_results_8x8_16x16_pu_avx2_intrin,
     };
 
-    static EbGeteightsaD32x32 FUNC_TABLE eb_vp9_get_eight_horizontal_search_point_results_32x32_64x64_func_ptr_array[ASM_TYPE_TOTAL] =
-    {
-        // C_DEFAULT
-        eb_vp9_get_eight_horizontal_search_point_results_32x32_64x64,
-        // AVX2
-        eb_vp9_get_eight_horizontal_search_point_results_32x32_64x64_pu_avx2_intrin,
+    static EbGeteightsaD32x32 FUNC_TABLE
+        eb_vp9_get_eight_horizontal_search_point_results_32x32_64x64_func_ptr_array
+            [ASM_TYPE_TOTAL] = {
+                // C_DEFAULT
+                eb_vp9_get_eight_horizontal_search_point_results_32x32_64x64,
+                // AVX2
+                eb_vp9_get_eight_horizontal_search_point_results_32x32_64x64,
+                // eb_vp9_get_eight_horizontal_search_point_results_32x32_64x64_pu_avx2_intrin produces worse results
     };
 #endif
 

--- a/Source/Lib/VPX/intrapred.c
+++ b/Source/Lib/VPX/intrapred.c
@@ -114,7 +114,6 @@ static INLINE void d135_predictor(uint8_t *dst, ptrdiff_t stride, int bs,
 #else
   uint8_t border[32 + 32 - 1];  // outer border from bottom-left to top-right
 #endif
-
   // dst(bs, bs - 2)[0], i.e., border starting at bottom-left
   for (i = 0; i < bs - 2; ++i) {
     border[i] = AVG3(left[bs - 3 - i], left[bs - 2 - i], left[bs - 1 - i]);
@@ -126,8 +125,7 @@ static INLINE void d135_predictor(uint8_t *dst, ptrdiff_t stride, int bs,
   for (i = 0; i < bs - 2; ++i) {
     border[bs + 1 + i] = AVG3(above[i], above[i + 1], above[i + 2]);
   }
-
-  for (i = 0; i < bs - 1; ++i) {
+  for (i = 0; i < bs; ++i) {
     memcpy(dst + i * stride, border + bs - 1 - i, bs);
   }
 }


### PR DESCRIPTION
There seemed to be an issue with `d135_predictor()` and `eb_vp9_get_eight_horizontal_search_point_results_32x32_64x64_pu_avx2_intrin()` that was causing a difference between the two asm choices. Additionally, I believe it was causing a run to run issue with `-asm 0`.
Specifically, the issue seemed to be with `eb_vp9_d135_predictor_8x8()`. For this, I just repulled the latest version from libvpx as it seems that it's not an issue there.
For the other, I've just disabled using the avx2 version until it can be investigated further, if ever.